### PR TITLE
use std::unique_ptr instead of std::auto_ptr

### DIFF
--- a/lru_cache.h
+++ b/lru_cache.h
@@ -49,7 +49,7 @@ class LRUCache {
 
   private:
     struct Impl;
-    std::auto_ptr<Impl> impl_;
+    std::unique_ptr<Impl> impl_;
 
     LRUCache(const LRUCache&);
     void operator=(const LRUCache&);


### PR DESCRIPTION
Not sure it shouldn't be std::shared_ptr but I think its this.